### PR TITLE
fix: normalize timestamps to support stocks from different exchanges …

### DIFF
--- a/backend/app/core/prices.py
+++ b/backend/app/core/prices.py
@@ -85,6 +85,8 @@ def get_price_history(symbol: str) -> pd.DataFrame:
         # Try to fetch if not exists
         if not update_price_cache(symbol):
             return pd.DataFrame()
-            
+
     df = pd.read_csv(file_path, index_col=0, parse_dates=True)
+    if not df.empty and hasattr(df.index, 'normalize'):
+        df.index = df.index.normalize()
     return df


### PR DESCRIPTION
This pull request introduces improvements to date handling in price history dataframes and adds a new utility function for fetching the latest foreign currency exchange rates. The main changes are grouped as follows:

**Data normalization improvements:**

* Ensured that DataFrame indices are normalized to midnight (removing time components) after loading price history data in both `get_price_history` in `backend/app/core/prices.py` and `get_historical_close` in `backend/data/fetch_data.py` to maintain consistency in date-based operations. [[1]](diffhunk://#diff-1714e417aab45a2bcd5580cde2abb2f11efe2619c37b3d7a9b5b66c7a8db1a4fR90-R91) [[2]](diffhunk://#diff-ae8752b54e5d758ec122cabe501c99ba9ca5e1a04128024152ad9887db573ba3R116)

**New functionality:**

* Added a new function `get_latest_foreign_currency` to `backend/data/fetch_data.py` that retrieves the latest closing price for a given currency pair using Yahoo Finance, handling errors gracefully and returning `None` if data is unavailable.…(closes #10)