### PR TITLE
Bug/fix benchmark comparison

### DIFF
--- a/frontend/components/BenchmarkComparisonTable.tsx
+++ b/frontend/components/BenchmarkComparisonTable.tsx
@@ -97,7 +97,7 @@ export function BenchmarkComparisonTable({ comparison }: BenchmarkComparisonTabl
                                     {renderMetricCell(data.metrics.alpha, true)}
                                 </td>
                                 <td className="text-right py-3 px-3">
-                                    {data.metrics.treynor_ratio !== undefined ? renderMetricCell(data.metrics.treynor_ratio) : <span className="text-gray-400">-</span>}
+                                    {data.metrics.treynor_ratio !== undefined ? renderMetricCell(data.metrics.treynor_ratio * 100) : <span className="text-gray-400">-</span>}
                                 </td>
                                 <td className="text-right py-3 px-3">
                                     {data.metrics.m2_measure !== undefined ? renderMetricCell(data.metrics.m2_measure, true) : <span className="text-gray-400">-</span>}


### PR DESCRIPTION
This pull request makes minor improvements to the `BenchmarkComparisonTable` component, focusing on display alignment and metric calculation.

- UI alignment:
  * Adjusted the metric cell container to right-align its contents by adding `justify-end` to the container's class list.

- Metric calculation:
  * Updated the Treynor Ratio display to multiply the value by 100 before rendering, likely to present it as a percentage.