### PR TITLE
feat: enhance AddTransactionModal to handle initial data and improve …

### DIFF
--- a/frontend/components/AddTransactionModal.tsx
+++ b/frontend/components/AddTransactionModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { TickerAutocomplete } from './TickerAutocomplete';
 
 interface AddTransactionModalProps {
@@ -12,10 +12,35 @@ interface AddTransactionModalProps {
 
 export function AddTransactionModal({ isOpen, onClose, onSubmit, initialData }: AddTransactionModalProps) {
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [symbol, setSymbol] = useState(initialData?.symbol || '');
-    const [side, setSide] = useState<'BUY' | 'SELL' | 'DEPOSIT' | 'WITHDRAW'>(initialData?.side || 'BUY');
+    const [symbol, setSymbol] = useState('');
+    const [side, setSide] = useState<'BUY' | 'SELL' | 'DEPOSIT' | 'WITHDRAW'>('BUY');
+
+    useEffect(() => {
+        if (isOpen) {
+            if (initialData) {
+                const actualSymbol = (initialData.side === 'DEPOSIT' || initialData.side === 'WITHDRAW') ? '' : (initialData.symbol || '');
+                setSymbol(actualSymbol);
+                setSide(initialData.side || 'BUY');
+            } else {
+                setSymbol('');
+                setSide('BUY');
+            }
+        }
+    }, [initialData, isOpen]);
 
     if (!isOpen) return null;
+
+    const formatDatetimeLocal = (dateStr: string | undefined): string => {
+        if (!dateStr) {
+            return new Date().toISOString().slice(0, 16);
+        }
+        try {
+            const date = new Date(dateStr);
+            return date.toISOString().slice(0, 16);
+        } catch {
+            return new Date().toISOString().slice(0, 16);
+        }
+    };
 
     async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -54,7 +79,8 @@ export function AddTransactionModal({ isOpen, onClose, onSubmit, initialData }: 
                             type="datetime-local"
                             name="datetime"
                             required
-                            defaultValue={initialData?.datetime || new Date().toISOString().slice(0, 16)}
+                            key={initialData?.datetime || 'new'}
+                            defaultValue={formatDatetimeLocal(initialData?.datetime)}
                             className="w-full px-3 py-2 border rounded-lg"
                         />
                     </div>
@@ -87,22 +113,54 @@ export function AddTransactionModal({ isOpen, onClose, onSubmit, initialData }: 
                         <div className="grid grid-cols-2 gap-4">
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-1">Quantity</label>
-                                <input type="number" step="any" name="quantity" required defaultValue={initialData?.quantity} className="w-full px-3 py-2 border rounded-lg" />
+                                <input
+                                    type="number"
+                                    step="any"
+                                    name="quantity"
+                                    required
+                                    key={`quantity-${initialData?.datetime || 'new'}`}
+                                    defaultValue={initialData?.quantity}
+                                    className="w-full px-3 py-2 border rounded-lg"
+                                />
                             </div>
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-1">Price</label>
-                                <input type="number" step="any" name="price" required defaultValue={initialData?.price} className="w-full px-3 py-2 border rounded-lg" />
+                                <input
+                                    type="number"
+                                    step="any"
+                                    name="price"
+                                    required
+                                    key={`price-${initialData?.datetime || 'new'}`}
+                                    defaultValue={initialData?.price}
+                                    className="w-full px-3 py-2 border rounded-lg"
+                                />
                             </div>
                         </div>
                     ) : (
                         <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">Amount</label>
-                            <input type="number" step="any" name="quantity" required defaultValue={initialData?.quantity} className="w-full px-3 py-2 border rounded-lg" placeholder="10000.00" />
+                            <input
+                                type="number"
+                                step="any"
+                                name="quantity"
+                                required
+                                key={`amount-${initialData?.datetime || 'new'}`}
+                                defaultValue={initialData?.quantity}
+                                className="w-full px-3 py-2 border rounded-lg"
+                                placeholder="10000.00"
+                            />
                         </div>
                     )}
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">Fee</label>
-                        <input type="number" step="any" name="fee" defaultValue={initialData?.fee || "0"} className="w-full px-3 py-2 border rounded-lg" />
+                        <input
+                            type="number"
+                            step="any"
+                            name="fee"
+                            key={`fee-${initialData?.datetime || 'new'}`}
+                            defaultValue={initialData?.fee || "0"}
+                            className="w-full px-3 py-2 border rounded-lg"
+                        />
                     </div>
 
                     <div className="flex justify-end gap-3 mt-6">


### PR DESCRIPTION
This pull request improves the transaction editing experience in the portfolio detail page and the `AddTransactionModal` component. The main focus is ensuring that editing a transaction correctly maps between the displayed (sorted) transaction list and the underlying data, and that the modal form fields reset and populate accurately when editing or adding transactions.

**Transaction editing and mapping improvements:**

* The logic for editing and deleting transactions in `page.tsx` now maps the displayed (sorted) transaction index back to the original data index, ensuring the correct transaction is edited or deleted regardless of sorting. It also stores the full transaction data for editing, not just the index. ([frontend/app/portfolio/[id]/page.tsxR52](diffhunk://#diff-18d45c8619e9e45e181dd219b5bbeba52d2952a7c6a94bf2e6b1e0fd99126f8eR52), [frontend/app/portfolio/[id]/page.tsxL72-R74](diffhunk://#diff-18d45c8619e9e45e181dd219b5bbeba52d2952a7c6a94bf2e6b1e0fd99126f8eL72-R74), [frontend/app/portfolio/[id]/page.tsxL156-R172](diffhunk://#diff-18d45c8619e9e45e181dd219b5bbeba52d2952a7c6a94bf2e6b1e0fd99126f8eL156-R172))
* When closing the add/edit transaction modal, both the editing index and editing data are reset to prevent stale data from persisting. ([frontend/app/portfolio/[id]/page.tsxR791-R794](diffhunk://#diff-18d45c8619e9e45e181dd219b5bbeba52d2952a7c6a94bf2e6b1e0fd99126f8eR791-R794))

**AddTransactionModal enhancements:**

* The modal now uses a `useEffect` to reset and populate form fields based on `initialData` and open state, ensuring the form always reflects the correct transaction data when opened for editing or adding.
* Added a utility function to format the datetime field for use with HTML `datetime-local` inputs, improving reliability of default values.
* Added `key` props to form fields dependent on transaction data to force React to reset their state when editing different transactions, preventing stale values from appearing. [[1]](diffhunk://#diff-ef2e7df203a37dcc91b85e30252d99b27e6fede4363779270eedb933f9f1eab2L57-R83) [[2]](diffhunk://#diff-ef2e7df203a37dcc91b85e30252d99b27e6fede4363779270eedb933f9f1eab2L90-R163)…datetime formatting