### PR TITLE
fix(data): correct X-Forwarded-For IP address format

### DIFF
--- a/backend/data/fetch_data.py
+++ b/backend/data/fetch_data.py
@@ -58,8 +58,7 @@ def get_stealth_headers() -> dict:
         'DNT': '1',
         'Pragma': 'no-cache',
         'X-Forwarded-For': (f"{random.randint(1,255)}.{random.randint(1,255)}."
-                            f"{random.randint(1,255)}.{random.randint(1,255)}."
-                            f"{random.randint(1,255)}"),
+                            f"{random.randint(1,255)}.{random.randint(1,255)}"),
         'X-Real-IP': (f"{random.randint(1,255)}.{random.randint(1,255)}."
                       f"{random.randint(1,255)}.{random.randint(1,255)}"),
         'X-Requested-With': 'XMLHttpRequest'


### PR DESCRIPTION
This pull request makes a minor correction to the construction of the `X-Forwarded-For` header in the `get_stealth_headers` function, ensuring the generated IP address format is correct.

- Fixed the formatting of the `X-Forwarded-For` header in `get_stealth_headers` by removing an unnecessary extra octet, so it now generates a valid IPv4 address.