### PR TITLE
Fix duplicate NavChart keys in translation files

### DIFF
--- a/frontend/components/NavChart.tsx
+++ b/frontend/components/NavChart.tsx
@@ -468,7 +468,7 @@ export function NavChart({ data, cashData = [], comparisonData = {}, benchmarkDa
                     />
                     <Tooltip
                         contentStyle={{ borderRadius: '8px', border: 'none', boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' }}
-                        formatter={(value: number) => [formatValue(value), isComparisonMode ? t('change') : t('nav')]}
+                        formatter={(value: number, name: string) => [formatValue(value), name]}
                         labelFormatter={(label: any) => new Date(label).toLocaleDateString()}
                     />
                     <Legend />

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -321,7 +321,9 @@
     "nav": "NAV",
     "peak": "Peak",
     "startDateError": "Start date cannot be earlier than",
-    "endDateError": "End date must be after start date"
+    "endDateError": "End date must be after start date",
+    "liquidationTooltip": "{symbol} converted to cash",
+    "liquidationAmount": "Amount: {amount}"
   },
   "LoadingProgress": {
     "loadingPortfolio": "Loading portfolio...",
@@ -426,9 +428,5 @@
     },
     "cancel": "Cancel",
     "confirm": "Apply & Continue"
-  },
-  "NavChart": {
-    "liquidationTooltip": "{symbol} converted to cash",
-    "liquidationAmount": "Amount: {amount}"
   }
 }

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -321,7 +321,9 @@
     "nav": "净值",
     "peak": "峰值",
     "startDateError": "开始日期不能早于",
-    "endDateError": "结束日期必须在开始日期之后"
+    "endDateError": "结束日期必须在开始日期之后",
+    "liquidationTooltip": "{symbol} 已转换为现金",
+    "liquidationAmount": "金额：{amount}"
   },
   "LoadingProgress": {
     "loadingPortfolio": "加载投资组合...",
@@ -426,9 +428,5 @@
     },
     "cancel": "取消",
     "confirm": "应用并继续"
-  },
-  "NavChart": {
-    "liquidationTooltip": "{symbol} 已转换为现金",
-    "liquidationAmount": "金额：{amount}"
   }
 }


### PR DESCRIPTION
Merge liquidationTooltip and liquidationAmount into the main NavChart object and remove the duplicate NavChart key at the end of both en.json and zh.json.

Fixes #71